### PR TITLE
Update bunyan version dependency fixes #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,12 @@
   },
   "homepage": "https://github.com/Floby/node-bunyan-blackhole",
   "dependencies": {
-    "bunyan": "~1.3.4",
     "stream-blackhole": "^1.0.3"
+  },
+  "peerDependencies": {
+    "bunyan": "~1.x.x"
+  },
+  "devDependencies": {
+    "bunyan": "1.8.1"
   }
 }


### PR DESCRIPTION
There is lot of DtraceProviderBindings errors on MacOSX fixed with bunyan 1.4 (or install with "--no-optional").
